### PR TITLE
iPhoneで見たときに「分」が気になるので

### DIFF
--- a/index.html
+++ b/index.html
@@ -167,19 +167,19 @@
                   </h3>
                   <ul class='venue__access-items'>
                     <li class='venue__access-item'>
-                      JR 中央線・総武線「御茶ノ水」駅
+                      JR 中央線・総武線 御茶ノ水駅
                       聖橋口から徒歩 1 分
                     </li>
                     <li class='venue__access-item'>
-                      東京メトロ千代田線「新御茶ノ水」駅
+                      東京メトロ千代田線 新御茶ノ水駅
                       B2出口 直結
                     </li>
                     <li class='venue__access-item'>
-                      東京メトロ丸ノ内線「御茶ノ水」駅
+                      東京メトロ丸ノ内線 御茶ノ水駅
                       出口1から徒歩 4 分
                     </li>
                     <li class='venue__access-item'>
-                      都営地下鉄 新宿線「小川町」駅
+                      都営地下鉄 新宿線 小川町駅
                       B3出口から徒歩 6 分
                     </li>
                   </ul>


### PR DESCRIPTION
アクセスの文面が、ひとまず会場公式からのこぴぺだとは思うんですが、手元のiPhoneで見た場合に
分
のところだけピロッと改行されて見えてかっこ悪い感じだったので、「」を取って調整してみました。

### before

<img width="169" alt="before" src="https://cloud.githubusercontent.com/assets/11493/22814030/925ec312-ef93-11e6-9855-de0e8af0dca8.png">

### after

<img width="171" alt="after" src="https://cloud.githubusercontent.com/assets/11493/22814033/98198abc-ef93-11e6-8758-1704fed95826.png">

/cc @machida @maztomo 