### PR TITLE
Add link to oedo02

### DIFF
--- a/data/oedo06/past_kaigis.yml
+++ b/data/oedo06/past_kaigis.yml
@@ -3,6 +3,7 @@ kaigis:
   - title: oedo01
     url: http://regional.rubykaigi.org/oedo01/
   - title: oedo02
+    url: http://magazine.rubyist.net/?0039-MetPragdaveAtAsakusarb
   - title: oedo03
     url: http://regional.rubykaigi.org/oedo03/
   - title: oedo04

--- a/source/partials/_past_kaigis.haml
+++ b/source/partials/_past_kaigis.haml
@@ -1,5 +1,5 @@
 %section.past-kaigis
-  %h2.past-kaigis__title Previous Events
+  %h2.past-kaigis__title 過去の開催
   %ol.past-kaigis__items
     - data.oedo06.past_kaigis.kaigis.each do |kaigi|
       %li.past-kaigis__item

--- a/source/partials/_past_kaigis.haml
+++ b/source/partials/_past_kaigis.haml
@@ -1,5 +1,5 @@
 %section.past-kaigis
-  %h2.past-kaigis__title Past Kaigis
+  %h2.past-kaigis__title Previous Events
   %ol.past-kaigis__items
     - data.oedo06.past_kaigis.kaigis.each do |kaigi|
       %li.past-kaigis__item


### PR DESCRIPTION
表記の件のついでに、`Past Kaigis` っていう言い回しはRubyKaigi用DSLなので、普通の書きかたに変えようとおもいます。
