### PR TITLE
Fix sponsor-logo

### DIFF
--- a/source/stylesheets/blocks/_sponsor.sass
+++ b/source/stylesheets/blocks/_sponsor.sass
@@ -7,9 +7,9 @@
   border-radius: 10px
   overflow: hidden
   align-items: flex-start
-  +size(13.75rem)
+  +size(13.75rem auto)
   +media-breakpoint-down(sm)
-    +size(4.5rem)
+    +size(4.5rem auto)
     margin-right: .5rem
     border: .25rem solid rgba($black, .18)
 


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/168265/23345860/b23bf21c-fcd7-11e6-8542-c4a5811f277d.png)

iPadで見たときにスポンサーロゴ画像が縦長になっている #33 対応
